### PR TITLE
ci(pages): force source '.' (root build, not ./docs)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,13 +1,18 @@
 name: Build and Deploy GitHub Pages
+
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
   contents: read
   pages: write
   id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -17,11 +22,11 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: actions/jekyll-build-pages@v1
         with:
-          source: '.'           # build from repo root
-          destination: './_site'
+          source: .
+          destination: ./_site
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: './_site'
+          path: ./_site
 
   deploy:
     needs: build


### PR DESCRIPTION
Align Pages to root build and artifact path.

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ]

## Summary by Sourcery

Update GitHub Pages workflow to build site from the repository root and improve workflow concurrency

Enhancements:
- Use repository root as the source for the Jekyll build step
- Remove unnecessary quotes from source, destination, and artifact path specifications
- Add concurrency configuration to cancel in-progress Pages workflow runs

CI:
- Adjust branch filter formatting for consistency