### PR TITLE
feat(ui): airport/real-estate theme base styles

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,23 +1,118 @@
 ---
 ---
-/* base */
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+/* FlightLine — Airport/Real-Estate UI
+   - sticky nav + sticky CTA bar
+   - clean cards, large tap targets
+   - accessible focus, high contrast, mobile-first
+*/
 
-/* support button */
-.btn-support { display:inline-block; padding:6px 12px; border:1px solid #d0d7de; border-radius:6px; text-decoration:none; }
-.btn-support:hover { background:#f6f8fa; }
+:root {
+  --bg: #f7f9fc;
+  --panel: #ffffff;
+  --ink: #0b1f3a;        /* deep navy (airport wayfinding) */
+  --muted-ink: #3b4b68;  /* slate */
+  --primary: #0f4c81;    /* runway blue */
+  --accent: #ffc107;     /* taxiway amber */
+  --border: #d0d7de;     /* subtle border */
+  --ring: #82b7ff;       /* accessible focus */
+  --container: 1080px;
+  --radius: 14px;
+  --shadow: 0 6px 18px rgba(11,31,58,0.08);
+  --sticky-gap: 10px;
+}
 
-/* CTA bar */
-.cta-bar { display:flex; flex-wrap:wrap; gap:10px; align-items:center; padding:8px 0 12px; border-bottom:1px solid #d0d7de; margin:0 16px 16px; }
-.cta-bar a { display:inline-block; padding:6px 10px; border:1px solid #d0d7de; border-radius:8px; text-decoration:none; }
+* { box-sizing: border-box; }
+html, body { margin:0; padding:0; }
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
+  color: var(--ink);
+  background: var(--bg);
+  line-height: 1.5;
+}
+
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+a:focus-visible, button:focus-visible {
+  outline: 3px solid var(--ring);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+.container { max-width: var(--container); margin: 0 auto; padding: 16px; }
+
+/* NAV (sticky) */
+.site-nav {
+  position: sticky; top: 0; z-index: 1000;
+  background: var(--panel); border-bottom: 1px solid var(--border);
+  box-shadow: 0 3px 14px rgba(11,31,58,0.04);
+}
+.site-nav .nav-inner { display: flex; align-items: center; gap: 16px; }
+.brand {
+  font-weight: 700; letter-spacing: 0.2px; color: var(--ink);
+}
+.links { display:flex; align-items:center; flex-wrap:wrap; gap: 6px; }
+.links a { color: var(--muted-ink); padding: 6px 2px; }
+.links a:hover { color: var(--ink); text-decoration: none; }
+.links a + a { position: relative; padding-left: 10px; }
+.links a + a::before {
+  content: " | "; position: absolute; left: -10px; color: var(--border);
+}
+.actions { margin-left: auto; }
+
+/* Buttons */
+.btn { display:inline-block; padding:10px 14px; border:1px solid var(--border);
+  border-radius: 999px; background: var(--panel); color: var(--ink);
+  text-decoration:none; box-shadow: 0 2px 6px rgba(11,31,58,0.04);
+}
+.btn:hover { background:#f6f8fa; text-decoration:none; }
+.btn-primary {
+  background: var(--primary); color: #fff; border-color: transparent;
+  box-shadow: 0 6px 16px rgba(15,76,129,0.22);
+}
+.btn-primary:hover { filter: brightness(1.05); }
+
+/* CTA BAR (sticky under nav) */
+.cta-wrap { position: sticky; top: 58px; z-index: 950; background: var(--panel); }
+.cta-bar {
+  display:flex; flex-wrap:wrap; gap:10px; align-items:center;
+  padding: 10px 0 14px; border-bottom:1px solid var(--border);
+}
+.cta-bar a {
+  display:inline-block; padding:10px 14px; border:1px solid var(--border);
+  border-radius: 12px; text-decoration:none; background:#fff;
+}
 .cta-bar a:hover { background:#f6f8fa; }
 
-/* gates */
-.gate-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:12px; }
-.gate-card { border:1px solid #d0d7de; border-radius:12px; padding:12px; }
+/* PAGE */
+.page-content.container { padding-top: 18px; }
 
-/* mobile safety */
+/* HERO (Home) */
+.hero {
+  background: linear-gradient(180deg, #ffffff 0%, #f7f9fc 100%);
+  border:1px solid var(--border); border-radius: var(--radius);
+  padding: 24px; box-shadow: var(--shadow);
+}
+.hero h1 { margin: 0 0 8px; font-size: clamp(22px, 3vw, 30px); }
+.hero p.lede { color: var(--muted-ink); margin: 6px 0 14px; }
+
+/* GATES */
+.gate-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:14px; }
+.gate-card {
+  border:1px solid var(--border); border-radius: var(--radius);
+  padding: 14px; background: var(--panel); box-shadow: var(--shadow);
+  display:flex; flex-direction:column; gap:10px;
+}
+.gate-card h3 { margin:0; font-size: 18px; }
+.gate-card p { margin:0; color: var(--muted-ink); }
+.gate-card .meta { font-size: 12px; color: var(--muted-ink); }
+.gate-card .cta { margin-top:auto; }
+
+/* FOOTER (optional future use) */
+footer { color: var(--muted-ink); font-size: 14px; padding: 24px 0; }
+
+/* MOBILE */
 @media (max-width: 768px) {
-  .cta-bar { position: sticky; top: 0; z-index: 1000; background: #fff; padding: 8px; }
-  .cta-bar a { flex: 1 1 auto; text-align:center; }
+  .links { gap: 2px; }
+  .actions { width: 100%; margin: 8px 0 0; }
+  .cta-wrap { top: 56px; } /* sticky offset under nav */
 }


### PR DESCRIPTION
- Add sticky nav + sticky CTA bar
- Card grid & real-estate look (shadow, radius)
- Accessible focus ring, mobile polish
- Central container & tokens (colors, spacing)

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ]

## Summary by Sourcery

Introduce a base airport/real-estate UI theme with design tokens, sticky navigation and CTA components, card and button styling, accessible focus states, and mobile-responsive layout support

New Features:
- Define CSS custom properties for theme tokens including colors, spacing, shadows, radii, and container width
- Add sticky site navigation bar and sticky call-to-action bar
- Introduce card grid layout and card styles with shadows and rounded corners for a real-estate look
- Implement button component styles with primary and default variants
- Add accessible focus outlines for links and buttons
- Add a central container class for consistent page width

Enhancements:
- Apply mobile-first responsive adjustments for navigation links, CTA bar placement, and spacing