### PR TITLE
refactor(layout): move width/padding inline styles to CSS

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,8 +10,8 @@
   <body>
     {% include nav.html %}
     {% include cta-bar.html %}
-    <main class="page-content" aria-label="Content" style="max-width:960px;margin:0 auto;padding:16px;">
-      {{ content }}
-    </main>
+    <main class="page-content container" aria-label="Content">
+  {{ content }}
+</main>
   </body>
 </html>


### PR DESCRIPTION
- Use .container utility for main content width/padding
- Keep includes (nav, cta) unchanged

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ]

## Summary by Sourcery

Enhancements:
- Replace inline max-width, margin, and padding styles on the main page-content element with the .container CSS class