### PR TITLE
docs(covenants): add /covenants index page (renders_data/covenants.yml

### DIFF
--- a/_pages/covenants.md
+++ b/_pages/covenants.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Covenants
+permalink: /covenants/
+---
+
+# Covenants
+
+Below is the live catalog of the 40 Memphis DC covenants. Click any title to jump; each section includes **Orders**, **Effect**, and **Proof Protocol**.
+
+{% assign covs = site.data.covenants %}
+{% if covs and covs.size > 0 %}
+
+<nav class="container" aria-label="Covenant index" style="margin:16px 0;">
+  <strong>Jump to:</strong>
+  <ul style="columns: 2; -webkit-columns: 2; -moz-columns: 2; padding-left: 18px;">
+  {% for c in covs %}
+    {% assign slug = c.slug | default: c.title | slugify %}
+    <li style="break-inside: avoid;"><a href="#{{ slug }}">{{ c.title }}</a></li>
+  {% endfor %}
+  </ul>
+</nav>
+
+{% for c in covs %}
+  {% include covenant-item.html c=c %}
+{% endfor %}
+
+{% else %}
+> No covenants found. Add items to **_data/covenants.yml**.
+{% endif %}


### PR DESCRIPTION
Creates a jump list and renders all covenants with the new include.

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ]

## Summary by Sourcery

Documentation:
- Introduce `covenants.md` in the pages directory with a jump-to index and loop includes to display each covenant using `covenant-item.html`.