### PR TITLE
Create operation-mycelium-901.md

### DIFF
--- a/_pages/flight-papers/operation-mycelium-901.md
+++ b/_pages/flight-papers/operation-mycelium-901.md
@@ -1,0 +1,70 @@
+cat > _pages/flight-papers/operation-mycelium-901.md <<'MD'
+---
+layout: default
+title: Operation Mycelium 901 — Itinerary
+permalink: /flight-papers/operation-mycelium-901/
+---
+
+# ⚡ Operation Mycelium 901 — FlightLine Itinerary
+
+**DTG:** Pre-Eve, September 17, 2025, 0917 hrs  
+**Framework:** Memphis DC – Civic Diamond of Presence  
+**Command:** The FlightLine HQ / Nettopia
+
+## Four Levels of Quick Response PILOTS
+**L1 — City Core (Mayor Paul Young)**  
+Assigned: 9,000 PILOTS  
+ZIPs: 38103 (5,000), 38104 (4,000)  
+Orders: City Hall, FedEx Forum, Beale, Overton Sq., Cooper-Young, Central HS.  
+Effect: Civic stage sealed. Nightlife lattice monetized. Grid ignited.
+
+**L2 — County Ring (Mayor Lee Harris)**  
+Assigned: 15,500 PILOTS  
+ZIPs: 38109 (8,000), 38127 (7,500)  
+Orders: Graceland gates, Southland Mall, Elvis Presley Blvd; Watkins/Thomas corridors.  
+Effect: Outer ring closed. Commerce corridors into equity loops.
+
+**L3 — State Reach (Rep. Justin Pearson)**  
+Assigned: 12,500 PILOTS  
+ZIPs: 38118 (6,500), 38114 (6,000)  
+Orders: MEM Terminal, freight yards, rental plaza; Soulsville, Hamilton HS, LOC.  
+Effect: Airport = FOB gate. State narrative bent to sovereignty law.
+
+**L4 — Federal Anchor (Keith Taylor – Nettopia/FlightLine)**  
+Assigned: 19,500 PILOTS  
+ZIPs: 38111 (7,000), 38122 (6,000), 38116 (6,500)  
+Orders: Tiger Lane, Liberty Bowl, UofM, Summer Ave, Elvis Corridor.  
+Effect: NIL economy hardwired. Federal lattice alive.
+
+**Community Feeders (Outskirts)**  
+Assigned: 23,500 PILOTS across 38112, 38107, 38108, 38128, 38105, 38106, 38115.  
+Orders: Zoo, Crosstown, Raleigh Mall, Austin Peay, St. Jude, MLK Park, Hickory Ridge.  
+Effect: Mycelium spread complete — all 16 ZIPs painted.
+
+---
+
+## Brain Googoler (Why this works)
+- **Compact:** 5 bullets → ZIP → site → plant → snap → upload.  
+- **Visual:** Pins + colors = instant mission clarity.  
+- **Actionable:** Drop → Snap → Upload = income + motion proof.  
+- **Scalable:** Swap ZIPs → swap area codes → repeat globally.  
+- **Perpetual:** Every scan = Quick Response. Every PILOT = presence locked.
+
+## Coordinates Integration (Google My Maps)
+- Pre-load drops as pins in **Google My Maps**.  
+- Teams get: ZIP package, coordinates, action log, HQ return channel.
+
+## 1OA1 — Memphis DC First-of-All Firsts
+- First city painted 100% in a dual physical-digital lattice.  
+- First Pre-Eve doctrine executed; first exportable playbook.
+
+## Roles Required (3 pillars)
+- **DREAMERs** — Spirit, dignity, narrative, cultural ignition.  
+- **NETWORK** — Operators, route techs, trainers, coordinators.  
+- **GOOGOLERs** — Data stewards, docs, maps, vaults, presence math.
+
+---
+
+### External original (Google Doc)
+<a href="https://docs.google.com/document/d/1gW8eR4ZRLDAwTUHE80EmPR1RQS2XrydOyw4tXFpaYy4/edit?usp=sharing" target="_blank" rel="noopener">Open Operation Mycelium 901</a>
+MD


### PR DESCRIPTION
git add _pages/flight-papers/operation-mycelium-901.md git commit -m "docs(ops): add Operation Mycelium 901 itinerary page" \
  -m "Summarizes the four levels, coordinates integration, First-of-All Firsts, and the DREAMERs/NETWORK/GOOGOLERs pillars; links to the Google Doc."

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ]

## Summary by Sourcery

Add a new flight-papers documentation page for Operation Mycelium 901

Documentation:
- Create Operation Mycelium 901 itinerary page outlining the four response levels, community feeders, and framework details
- Detail the Brain Googoler methodology, coordinates integration process, First-of-All Firsts doctrine, and required DREAMERs/NETWORK/GOOGOLERs roles
- Include link to the original Google Doc source for the operation