### PR TITLE
Update style.scss

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,9 +1,7 @@
----
----
-/* FlightLine — Airport/Real-Estate UI
-   - sticky nav + sticky CTA bar
-   - clean cards, large tap targets
-   - accessible focus, high contrast, mobile-first
+/* FlightLine — Airport × Real-Estate UI (FULL REPLACE)
+   - sticky nav + sticky CTA bar (accessible)
+   - terminal-style cards + large tap targets
+   - mobile-first, high contrast, keyboard focus rings
 */
 
 :root {
@@ -15,10 +13,10 @@
   --accent: #ffc107;     /* taxiway amber */
   --border: #d0d7de;     /* subtle border */
   --ring: #82b7ff;       /* accessible focus */
-  --container: 1080px;
-  --radius: 14px;
+  --container: 1100px;   /* terminal content width */
+  --radius: 16px;
   --shadow: 0 6px 18px rgba(11,31,58,0.08);
-  --sticky-gap: 10px;
+  --nav-h: 58px;         /* sticky nav height */
 }
 
 * { box-sizing: border-box; }
@@ -28,6 +26,8 @@ body {
   color: var(--ink);
   background: var(--bg);
   line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 a { color: var(--primary); text-decoration: none; }
@@ -38,55 +38,55 @@ a:focus-visible, button:focus-visible {
   border-radius: 8px;
 }
 
-.container { max-width: var(--container); margin: 0 auto; padding: 16px; }
+.container { max-width: var(--container); margin: 0 auto; padding: 0 16px; }
 
-/* NAV (sticky) */
+/* ===== NAV (sticky) ===== */
 .site-nav {
   position: sticky; top: 0; z-index: 1000;
   background: var(--panel); border-bottom: 1px solid var(--border);
   box-shadow: 0 3px 14px rgba(11,31,58,0.04);
 }
 .site-nav .nav-inner { display: flex; align-items: center; gap: 16px; }
-.brand {
-  font-weight: 700; letter-spacing: 0.2px; color: var(--ink);
-}
-.links { display:flex; align-items:center; flex-wrap:wrap; gap: 6px; }
-.links a { color: var(--muted-ink); padding: 6px 2px; }
-.links a:hover { color: var(--ink); text-decoration: none; }
-.links a + a { position: relative; padding-left: 10px; }
-.links a + a::before {
-  content: " | "; position: absolute; left: -10px; color: var(--border);
-}
+.brand { font-weight: 700; letter-spacing: 0.2px; color: var(--ink); }
+.site-nav .links { display:flex; align-items:center; flex-wrap:wrap; gap: 6px; line-height: 1.3; }
+.site-nav .links a { color: var(--muted-ink); padding: 6px 2px; }
+.site-nav .links a:hover { color: var(--ink); text-decoration: none; }
+.site-nav .links a + a { position: relative; padding-left: 10px; }
+.site-nav .links a + a::before { content: " | "; position: absolute; left: -10px; color: var(--border); }
 .actions { margin-left: auto; }
 
-/* Buttons */
-.btn { display:inline-block; padding:10px 14px; border:1px solid var(--border);
+/* ===== Buttons ===== */
+.btn {
+  display:inline-block; padding:10px 14px; border:1px solid var(--border);
   border-radius: 999px; background: var(--panel); color: var(--ink);
-  text-decoration:none; box-shadow: 0 2px 6px rgba(11,31,58,0.04);
+  text-decoration:none; box-shadow: 0 2px 6px rgba(11,31,58,0.06);
+  transition: filter .12s ease, transform .12s ease;
 }
-.btn:hover { background:#f6f8fa; text-decoration:none; }
+.btn:hover { background:#f6f8fa; text-decoration:none; transform: translateY(-1px); }
 .btn-primary {
   background: var(--primary); color: #fff; border-color: transparent;
   box-shadow: 0 6px 16px rgba(15,76,129,0.22);
 }
 .btn-primary:hover { filter: brightness(1.05); }
 
-/* CTA BAR (sticky under nav) */
-.cta-wrap { position: sticky; top: 58px; z-index: 950; background: var(--panel); }
+/* ===== CTA BAR (sticky under nav) ===== */
+.cta-wrap { position: sticky; top: var(--nav-h); z-index: 950; background: var(--panel); }
+.cta-wrap .container { padding-top: 6px; }
 .cta-bar {
   display:flex; flex-wrap:wrap; gap:10px; align-items:center;
-  padding: 10px 0 14px; border-bottom:1px solid var(--border);
+  padding: 8px 0 12px; border-bottom:1px solid var(--border);
 }
 .cta-bar a {
   display:inline-block; padding:10px 14px; border:1px solid var(--border);
-  border-radius: 12px; text-decoration:none; background:#fff;
+  border-radius: 12px; text-decoration:none; background:#fff; color: var(--muted-ink);
+  box-shadow: 0 2px 6px rgba(11,31,58,0.04);
 }
-.cta-bar a:hover { background:#f6f8fa; }
+.cta-bar a:hover { background:#f6f8fa; color: var(--ink); text-decoration:none; }
 
-/* PAGE */
+/* ===== PAGE ===== */
 .page-content.container { padding-top: 18px; }
 
-/* HERO (Home) */
+/* ===== HERO (Home) ===== */
 .hero {
   background: linear-gradient(180deg, #ffffff 0%, #f7f9fc 100%);
   border:1px solid var(--border); border-radius: var(--radius);
@@ -95,8 +95,12 @@ a:focus-visible, button:focus-visible {
 .hero h1 { margin: 0 0 8px; font-size: clamp(22px, 3vw, 30px); }
 .hero p.lede { color: var(--muted-ink); margin: 6px 0 14px; }
 
-/* GATES */
-.gate-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:14px; }
+/* ===== GATES (cards grid) ===== */
+.gate-grid {
+  display:grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap:14px;
+}
 .gate-card {
   border:1px solid var(--border); border-radius: var(--radius);
   padding: 14px; background: var(--panel); box-shadow: var(--shadow);
@@ -107,12 +111,48 @@ a:focus-visible, button:focus-visible {
 .gate-card .meta { font-size: 12px; color: var(--muted-ink); }
 .gate-card .cta { margin-top:auto; }
 
-/* FOOTER (optional future use) */
-footer { color: var(--muted-ink); font-size: 14px; padding: 24px 0; }
+/* ===== Flight Papers — airport × real-estate cards ===== */
+.paper-grid{
+  display:grid;
+  grid-template-columns: repeat(auto-fit,minmax(220px,1fr));
+  gap:16px;
+  margin:16px 0 24px;
+}
+.paper-card{
+  display:block;
+  padding:16px;
+  border:1px solid var(--border);
+  border-radius: var(--radius);
+  background:#ffffff;
+  box-shadow: var(--shadow);
+  text-decoration:none;
+  transition:transform .12s ease, box-shadow .12s ease, border-color .12s ease;
+}
+.paper-card:hover,.paper-card:focus{
+  transform:translateY(-2px);
+  box-shadow:0 10px 24px rgba(16,24,40,.10);
+  border-color:#9aa3af;
+}
+.paper-card h3{margin:0 0 4px;font-size:1.05rem;color:var(--ink)}
+.paper-card p{margin:0;color:#475467}
 
-/* MOBILE */
+/* ===== FOOTER ===== */
+.site-footer{
+  margin-top: 24px;
+  padding: 16px 0;
+  border-top: 1px solid var(--border);
+  background: #fff;
+  position: static; /* normal flow at bottom */
+}
+
+/* ===== ACCESSIBILITY UTIL ===== */
+.sr-only {
+  position:absolute !important; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;
+}
+
+/* ===== MOBILE ===== */
 @media (max-width: 768px) {
-  .links { gap: 2px; }
+  .site-nav .links { gap: 2px; }
   .actions { width: 100%; margin: 8px 0 0; }
-  .cta-wrap { top: 56px; } /* sticky offset under nav */
+  .cta-wrap { top: calc(var(--nav-h) - 2px); } /* keep snug under nav */
 }


### PR DESCRIPTION
git add assets/css/style.scss
git commit -m "style(ui): merge airport × real-estate theme + Flight Papers cards (full replace)" \
  -m "Full stylesheet consolidation: sticky nav + sticky CTA, container, terminal focus ring, Gate and Flight Papers card grids, mobile wrapping, accessible colors."

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ]

## Summary by Sourcery

Update style.scss to replace and consolidate the UI theme for an airport × real-estate design, improve accessibility, reorganize sectioning, and add new Flight Papers cards and utility styles.

New Features:
- Introduce Flight Papers card grid with interactive card styles and hover/focus transitions
- Add sr-only utility class for visually hidden content

Enhancements:
- Consolidate stylesheet into unified airport × real-estate theme with sticky nav and CTA bar
- Update root variables to adjust container width, border radius, nav height, and enable font smoothing
- Enhance button and link styles with transitions, consistent hover effects, and accessible focus rings
- Restructure CSS with clear section comment markers for better organization
- Refine responsive behavior by adjusting mobile nav and CTA offset using CSS variables