### PR TITLE
docs(structure): add covenant/ engine/ network/ directories with READMEs

### DIFF
--- a/covenant/README.md
+++ b/covenant/README.md
@@ -1,0 +1,6 @@
+# Covenant Engine
+Authoritative covenant texts and protocols.
+
+- Source of truth for long-form covenant markdown
+- Mirrors what renders on **/covenants** (site)
+- Each doc maps to a covenant section (level/scope/orders/effect/proof)

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,0 +1,5 @@
+# Engine
+CUDA pilots, sims, streaming rules, and automation scripts.
+
+- Keep runnable code and configs here
+- CI can execute sims and export artifacts to `network/` for publishing

--- a/network/README.md
+++ b/network/README.md
@@ -1,0 +1,5 @@
+# Network
+Maps, QR sets, ledgers.
+
+- QR images (png/svg), JSON for Google My Maps exports, and ledger CSVs
+- Site can surface summaries; raw data lives here for reuse


### PR DESCRIPTION
Aligns repo with SOP (3 engines), without changing the Jekyll site structure.

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ]

## Summary by Sourcery

Add covenant, engine, and network top-level directories each with an initial README to align the repository structure with the SOP.

Documentation:
- Create covenant/ with README outlining covenant texts and protocols
- Create engine/ with README describing CUDA pilots, simulations, streaming rules, and automation scripts
- Create network/ with README detailing maps, QR sets, ledgers, and raw data formats