### PR TITLE
dev(codespaces): add Jekyll Codespaces devcontainer + live preview

### DIFF
--- a/dev/codespaces-boot
+++ b/dev/codespaces-boot
@@ -1,0 +1,13 @@
+{
+  "name": "FlightLine (Jekyll)",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/ruby:1": { "version": "3.2" },
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" }
+  },
+  "postCreateCommand": "bash .devcontainer/postCreate.sh",
+  "forwardPorts": [4000],
+  "portsAttributes": {
+    "4000": { "label": "Jekyll", "onAutoForward": "notify" }
+  }
+}


### PR DESCRIPTION
Adds .devcontainer with Ruby+Node features, Gemfile for GitHub Pages, postCreate bootstrap, and a serve script. Use “Run > Start Debugging” or run scripts/serve.sh to preview on port 4000 with livereload.

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ]

## Summary by Sourcery

Configure Codespaces devcontainer for Jekyll with environment setup and live preview capabilities

New Features:
- Add .devcontainer configuration including Ruby and Node features for Jekyll development in Codespaces
- Include a Gemfile to manage GitHub Pages dependencies
- Add a postCreate command to bootstrap the development environment after container creation
- Introduce scripts/serve.sh and VSCode launch configuration to serve the site with live reload on port 4000