### PR TITLE
docs: OPORD ANNEX page + contact email (mailto) in Contact & footer

### DIFF
--- a/_pages/flight-papers/opord-memphis-dc.md
+++ b/_pages/flight-papers/opord-memphis-dc.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: OPORD ANNEX — Memphis DC / Nettopia (Civic Diamond Activation)
+permalink: /flight-papers/opord-memphis-dc/
+---
+
+# OPORD ANNEX: Memphis DC / Nettopia – Civic Diamond Activation
+
+**Mission:** Establish Memphis DC as the first perpetual Digital Civilization, generating continuous civic stability, protection, and revenue for every household, ZIP code, and leader.
+
+## 1. Situation
+**Environment:** National Guard deployment highlights urgency for civic trust and order.  
+**Problem:** Memphis faces crime perception, inequality, and lack of digital-first governance.  
+**Opportunity:** **Googoler Time** compresses 2,740 years of progress into 60 days.  
+**Authority:** The **Civic Diamond** — *Mayor Paul Young (City), Mayor Lee Harris (County), Rep. Justin J. Pearson (State), Keith Taylor (Federal Veteran)* — holds activation authority.
+
+## 2. Mission
+Activate seven operational wings of continuity aligned to people-first infrastructure, perpetual revenue generation, and cosmic memory.
+
+## 3. Execution
+*(7 Wings: Infinity, Cosmic, Biological, Historical, Digital, Spiritual, Forgotten — with tasks, connections, memory, revenue, and leader suggestions.)*
+
+## 4. Sustainment
+**People:** Every ZIP engaged with tools for jobs, health, history, hope, and healing.  
+**Revenue:** Continuous cycles via digital leases, AI programs, tourism, and grants.  
+**Governance:** **QRaaS Inc.** ensures standards, colors, and minimal digital waste.
+
+## 5. Command & Signal
+**Command:** Civic Diamond — Young (City), Harris (County), Pearson (State), Taylor (Federal Veteran).  
+**Signal:** Black Code posters as covert/overt civic communication.  
+**Googoler Time:** Every 60 days completes a full rotation of the 7 Doors → perpetual advancement.
+
+---
+
+### Bottom Line
+This OPORD provides ready-to-execute infrastructure.  
+**For the people:** immediate benefits in every ZIP.  
+**For leaders:** perpetual revenue + national recognition.  
+**For the city:** first Digital Civilization — *1,000,000 days ahead of schedule in 60 days.*
+
+---
+
+### Signature Blocks
+**For the City of Memphis** — Mayor Paul Young, City Executive  
+**For Shelby County** — Mayor Lee Harris, County Executive  
+**For the State of Tennessee** — Rep. Justin J. Pearson, District 86  
+**For the Federal Veteran Mandate** — Keith D. Taylor, Sr., Retired U.S. Army
+


### PR DESCRIPTION
What changed
- New page: /flight-papers/opord-memphis-dc/ (OPORD ANNEX — Civic Diamond Activation).
- Flight Papers hub: added “OPORD — Memphis DC / Nettopia” to Jump list.
- Contact page: added mailto link for taylor@theflightlinehq.com.
- Footer: added Email link (mailto).

Why
- Make command doctrine public and linkable under Flight Papers.
- Provide a direct workspace contact link across the site.

Testing
- Build & Deploy GitHub Pages ✅
- pages build and deployment ✅
- /flight-papers/opord-memphis-dc/ loads with content.
- /flight-papers/ shows the OPORD jump link.
- /contact/ shows the email; footer shows Email link; both open mail client.
