### PR TITLE
Wire JT iii Neon Brain Concourse image like Proof Stack visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -544,74 +544,77 @@
     <!-- ========================= -->
 
     <section id="jt-iii" class="mt-4 mb-12">
-      <div class="text-center mb-6">
-        <h2 class="text-2xl md:text-3xl font-bold neon-title">Johnnie Taylor III · JT iii Stewardship Matrix</h2>
-        <p class="text-sm md:text-base text-slate-300 mt-1">
-          Intelligent Interactive Impact over three numbers: people, land, and water.
-        </p>
-        <p class="text-xs md:text-sm text-slate-400 max-w-3xl mx-auto mt-2">
-          We measure our work against three numbers:
-          ~8.2B people · ~37B acres of land · ~3.7 × 10²⁰ gallons of water.
-          Your placement on the FlightLine is a promise to help close gaps for people, land, and water.
-        </p>
-      </div>
+  <div class="text-center mb-6">
+    <h2 class="text-2xl md:text-3xl font-bold neon-title">Johnnie Taylor III · JT iii Stewardship Matrix</h2>
+    <p class="text-sm md:text-base text-slate-300 mt-1">
+      Intelligent Interactive Impact over three numbers: people, land, and water.
+    </p>
+    <p class="text-xs md:text-sm text-slate-400 max-w-3xl mx-auto mt-2">
+      We measure our work against three numbers:
+      ~8.2B people · ~37B acres of land · ~3.7 × 10²⁰ gallons of water.
+      Your placement on the FlightLine is a promise to help close gaps for people, land, and water.
+    </p>
+  </div>
 
-      <div class="grid gap-6 md:grid-cols-2 items-stretch">
-        <div class="space-y-3 text-xs md:text-sm text-slate-300">
-          <p>
-            JT iii is not a job application. It is a <span class="font-semibold">covenant seat</span>
-            with FlightLine HQ, FlightLine – The Division, and NETTOPIA.
-          </p>
-          <p>
-            Your answers on the JT iii form place you inside:
-          </p>
-          <ul class="list-disc list-inside space-y-1">
-            <li>Creator Wing – positioning, design, infrastructure, and blueprints.</li>
-            <li>Producer Wing – expansion, branding, profit, and execution.</li>
-            <li>Bridge Seats – translating between creators, producers, and families.</li>
-          </ul>
-          <p>
-            From there, we align you with Gates (G1–G17) and Tiers across
-            storefronts, neighborhoods, cities, regions, and BTC Travel corridors.
-          </p>
-          <p class="text-slate-400">
-            Your JT iii placement is honored as part of the Flight Papers and can be tied
-            directly into a FlightLine P.C. Meeting for live cockpit work.
+  <div class="grid gap-6 md:grid-cols-2 items-stretch">
+    <!-- LEFT: JT iii copy -->
+    <div class="space-y-3 text-xs md:text-sm text-slate-300">
+      <p>
+        JT iii is not a job application. It is a <span class="font-semibold">covenant seat</span>
+        with FlightLine HQ, FlightLine – The Division, and NETTOPIA.
+      </p>
+      <p>Your answers on the JT iii form place you inside:</p>
+      <ul class="list-disc list-inside space-y-1">
+        <li>Creator Wing – positioning, design, infrastructure, and blueprints.</li>
+        <li>Producer Wing – expansion, branding, profit, and execution.</li>
+        <li>Bridge Seats – translating between creators, producers, and families.</li>
+      </ul>
+      <p>
+        From there, we align you with Gates (G1–G17) and Tiers across
+        storefronts, neighborhoods, cities, regions, and BTC Travel corridors.
+      </p>
+      <p class="text-slate-400">
+        Your JT iii placement is honored as part of the Flight Papers and can be tied
+        directly into a FlightLine P.C. Meeting for live cockpit work.
+      </p>
+    </div>
+
+    <!-- RIGHT: JT iii image card (same style as Proof Stack) -->
+    <article class="board-frame border border-fuchsia-300/70 bg-slate-950/95 rounded-2xl overflow-hidden flex flex-col">
+      <div class="relative overflow-hidden">
+        <div class="pointer-events-none absolute inset-0 bg-gradient-to-tr from-fuchsia-500/10 via-transparent to-cyan-400/10 mix-blend-soft-light"></div>
+
+        <img
+          src="AZq5173_x5WadoB862rLpQ-AZq5173_sDljNEXD2i6y2g.jpg"
+          alt="JT iii Lounge · Neon Brain Concourse inside the FlightLine Memphis DC terminal."
+          class="w-full h-56 object-cover rounded-t-2xl brightness-110 saturate-125"
+        />
+
+        <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-950 via-slate-950/60 to-transparent px-4 py-3 text-[11px]">
+          <p class="text-slate-100 font-semibold">JT iii Lounge · Neon Brain Concourse</p>
+          <p class="text-slate-300">
+            One concourse for stewards who accept responsibility for people, land, and water through the FlightLine grid.
           </p>
         </div>
-
-        <div class="board-frame border border-fuchsia-300/70 bg-slate-950/95 rounded-2xl overflow-hidden flex flex-col">
-          <div class="relative overflow-hidden">
-            <div class="pointer-events-none absolute inset-0 bg-gradient-to-tr from-fuchsia-500/10 via-transparent to-cyan-400/10 mix-blend-soft-light"></div>
-            <img
-  src="AZq5173_x5WadoB862rLpQ-AZq5173_sDljNEXD2i6y2g.jpg"
-  alt="JT iii Lounge · Neon Brain Concourse inside the FlightLine Memphis DC terminal."
-  class="w-full h-56 object-cover rounded-t-2xl brightness-110 saturate-125"
-/>
-            />
-            <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-slate-950 via-slate-950/60 to-transparent px-4 py-3 text-[11px]">
-              <p class="text-slate-100 font-semibold">JT iii Lounge · Neon Brain Concourse</p>
-              <p class="text-slate-300">
-                One concourse for stewards who accept responsibility for people, land, and water through the FlightLine grid.
-              </p>
-            </div>
-          </div>
-          <div class="p-4 flex-1 flex flex-col justify-between">
-            <p class="text-xs text-slate-300 mb-3">
-              Step into the JT iii matrix to declare where you stand, what you carry, and which gates and tiers fit your calling.
-            </p>
-            <a
-              href="https://docs.google.com/forms/d/e/1FAIpQLScXQXfA2BUkA4R5rvCI1mr3GFcPiYAkESVWWWCB0kde3OO9nw/viewform?usp=header"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="mt-auto inline-flex justify-center w-full px-4 py-2.5 rounded-full bg-fuchsia-500 text-slate-950 text-xs md:text-sm font-semibold hover:bg-fuchsia-400 transition"
-            >
-              Enter JT iii Stewardship Matrix
-            </a>
-          </div>
-        </div>
       </div>
-    </section>
+
+      <div class="p-4 flex-1 flex flex-col justify-between">
+        <p class="text-xs text-slate-300 mb-3">
+          Step into the JT iii matrix to declare where you stand, what you carry,
+          and which gates and tiers fit your calling.
+        </p>
+        <a
+          href="https://docs.google.com/forms/d/e/1FAIpQLScXQXfA2BUkA4R5rvCI1mr3GFcPiYAkESVWWWCB0kde3OO9nw/viewform?usp=header"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="mt-auto inline-flex justify-center w-full px-4 py-2.5 rounded-full bg-fuchsia-500 text-slate-950 text-xs md:text-sm font-semibold hover:bg-fuchsia-400 transition"
+        >
+          Enter JT iii Stewardship Matrix
+        </a>
+      </div>
+    </article>
+  </div>
+</section>
 
     <!-- ========================= -->
     <!--  DSX PACKS BOARD         -->


### PR DESCRIPTION
Set up the JT iii Stewardship Matrix card to use the uploaded neon brain concourse image, matching the structure and styling of the Proof Stack image cards. The image now loads from the repo root and uses the same gradient overlay, caption band, and CTA layout.

## What changed
-

## Why (mission link)
-

## Checklist
- [ ] Builds locally
- [ ] Pages workflow green
- [ ] Updated `_data`/nav if needed
- [ ] Linked issue & milestone
- [ ] 
